### PR TITLE
Use git-config action from CI repo, cleanup .gitconfig

### DIFF
--- a/.github/workflows/MCCE-Test-Linux.yml
+++ b/.github/workflows/MCCE-Test-Linux.yml
@@ -27,7 +27,7 @@ jobs:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Set access token
@@ -39,14 +39,14 @@ jobs:
           pip install mbed-cli
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out scripts-internal repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: PelionIoT/scripts-internal
           token: ${{ secrets.ACCESS_TOKEN }}
           path: ${{ env.SCRIPTS_INTERNAL_DIR }}
           ref: 'master'
       - name: Check out MCCE repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: PelionIoT/mbed-cloud-client-example-internal
           token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,48 +9,54 @@ concurrency:
   
 jobs:
   run-pysh-check:
-    runs-on: ubuntu-22.04
+    runs-on: client
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt-get install black pycodestyle pydocstyle shellcheck python3
       - run: black --version
-      - name: Set access token
-        run: |
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
+      - uses: PelionIoT/continuous-integration/.github/actions/git-config@master
+        with:
+          github_token: ${{ secrets.ACCESS_TOKEN }}
       - run: git clone https://github.com/PelionIoT/scripts-internal
       # Lets not run pysh-check on itself (it already has PR job for it)
       - run: echo . >scripts-internal/.nopyshcheck
       - run: scripts-internal/pysh-check/pysh-check.sh --workdir .
+      - name: Cleanup .gitconfig
+        run: rm -f ~/.gitconfig
 
   install-on-ubuntu-22-04:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: Set access token
-        run: |
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
+      - uses: PelionIoT/continuous-integration/.github/actions/git-config@master
+        with:
+          github_token: ${{ secrets.ACCESS_TOKEN }}
       - name: Install e2e-python-test-library
         run: |
           pip install wheel
           python3 setup.py bdist_wheel
           cd dist/
           pip install -I client_test_lib*.whl
+      - name: Cleanup .gitconfig
+        run: rm -f ~/.gitconfig
+  
   install-on-ubuntu-20-04:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Set access token
-        run: |
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
+      - name: Set access token for mbed deploy
+        uses: PelionIoT/continuous-integration/.github/actions/git-config@master
+        with:
+          github_token: ${{ secrets.ACCESS_TOKEN }}
       - name: Install e2e-python-test-library
         run: |
           pip install wheel
           python3 setup.py bdist_wheel
           cd dist/
           pip install -I client_test_lib*.whl
+      - name: Cleanup .gitconfig
+        run: rm -f ~/.gitconfig
+
   call-mcce-linux:
     # Note - primary/master version of this test is in the mcce-repo.
     uses: ./.github/workflows/MCCE-Test-Linux.yml

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: client
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get install black pycodestyle pydocstyle shellcheck python3
+      - run: sudo apt-get update && sudo apt-get install -y black pycodestyle pydocstyle shellcheck python3
       - run: black --version
       # We cannot use the one in the continuous-integration-repo, 
       # because public repos cannot use actions in private repos.

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,7 +14,12 @@ jobs:
       - uses: actions/checkout@v4
       - run: sudo apt-get install black pycodestyle pydocstyle shellcheck python3
       - run: black --version
-
+      # We cannot use the one in the continuous-integration-repo, 
+      # because public repos cannot use actions in private repos.
+      - name: Set access token
+        run: |
+          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
       - run: git clone https://github.com/PelionIoT/scripts-internal
       # Lets not run pysh-check on itself (it already has PR job for it)
       - run: echo . >scripts-internal/.nopyshcheck

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -25,6 +25,7 @@ jobs:
       - run: echo . >scripts-internal/.nopyshcheck
       - run: scripts-internal/pysh-check/pysh-check.sh --workdir .
       - name: Cleanup .gitconfig
+        if: always()
         run: rm -f ~/.gitconfig
 
   install-on-ubuntu-22-04:
@@ -38,6 +39,7 @@ jobs:
           cd dist/
           pip install -I client_test_lib*.whl
       - name: Cleanup .gitconfig
+        if: always()
         run: rm -f ~/.gitconfig
   
   install-on-ubuntu-20-04:
@@ -51,6 +53,7 @@ jobs:
           cd dist/
           pip install -I client_test_lib*.whl
       - name: Cleanup .gitconfig
+        if: always()
         run: rm -f ~/.gitconfig
 
   call-mcce-linux:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,7 +11,7 @@ jobs:
   run-pysh-check:
     runs-on: client
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo apt-get install black pycodestyle pydocstyle shellcheck python3
       - run: black --version
       - uses: PelionIoT/continuous-integration/.github/actions/git-config@master
@@ -27,7 +27,7 @@ jobs:
   install-on-ubuntu-22-04:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: PelionIoT/continuous-integration/.github/actions/git-config@master
         with:
           github_token: ${{ secrets.ACCESS_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
   install-on-ubuntu-20-04:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set access token for mbed deploy
         uses: PelionIoT/continuous-integration/.github/actions/git-config@master
         with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,9 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: sudo apt-get install black pycodestyle pydocstyle shellcheck python3
       - run: black --version
-      - uses: PelionIoT/continuous-integration/.github/actions/git-config@master
-        with:
-          github_token: ${{ secrets.ACCESS_TOKEN }}
+
       - run: git clone https://github.com/PelionIoT/scripts-internal
       # Lets not run pysh-check on itself (it already has PR job for it)
       - run: echo . >scripts-internal/.nopyshcheck
@@ -28,9 +26,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: PelionIoT/continuous-integration/.github/actions/git-config@master
-        with:
-          github_token: ${{ secrets.ACCESS_TOKEN }}
       - name: Install e2e-python-test-library
         run: |
           pip install wheel
@@ -44,10 +39,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - name: Set access token for mbed deploy
-        uses: PelionIoT/continuous-integration/.github/actions/git-config@master
-        with:
-          github_token: ${{ secrets.ACCESS_TOKEN }}
       - name: Install e2e-python-test-library
         run: |
           pip install wheel


### PR DESCRIPTION
Re-use the action. Clean up the PAT afterwards.
Also, `pysh-check` gets run on self-hosted `client` runner.


