### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/MCCE-Test-Linux.yml
+++ b/.github/workflows/MCCE-Test-Linux.yml
@@ -8,7 +8,14 @@ on:
         description: 'MCCE branch to pull'
         default: 'master'
         required: false
-        type: string      
+        type: string
+  workflow_dispatch:
+    inputs:
+      tested_branch: 
+        description: 'MCCE branch to pull'
+        default: 'master'
+        required: false
+        type: string
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -30,10 +37,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.8'
-      - name: Set access token
-        run: |
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
+      - name: Set access token for internal repo access
+        uses: PelionIoT/actions/.github/actions/git-config@main
+        with:
+          github_token: ${{ secrets.ACCESS_TOKEN }}
       - name: Install mbed-cli
         run: |
           pip install mbed-cli
@@ -83,3 +90,6 @@ jobs:
           pip install git+https://${{ secrets.ACCESS_TOKEN }}@github.com/PelionIoT/raas-pyclient.git#egg=raas-client
           pytest TESTS/client-e2e-python-test-library/tests/dev-client-tests.py --update_bin=__x86_x64_NativeLinux_mbedtls/Debug/mbedCloudClientExample.elf --local_binary=__x86_x64_NativeLinux_mbedtls/Debug/mbedCloudClientExample.elf --log-cli-level=DEBUG
       - run: echo "🍏 This job's status is ${{ job.status }}."
+      - name: Cleanup .gitconfig
+        if: always()
+        run: rm -f ~/.gitconfig

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The library is designed to be used with the [pytest test framework](https://docs
 
 ## Prerequisites
 
-Python 3.5 or later.
+Python 3.8 or later.
 
 ## Installation
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Client E2E Python Test Library Changelog
 
+## 0.5.0 2024-10-x
+- Update `pytest` to `7.4.4`.
+- Update `requests` to `2.32.3`.
+- Update `manifest-tool` to version 2.6.2 (due to `requests` `2.32.3`).
+
 ## 0.4.0 2023-12-11
 - Rename the library to client-e2e-python-test-library.
     - Rename `PELION_CLOUD_API_KEY` to `CLOUD_API_KEY`.
@@ -10,14 +15,14 @@
 - Izuma branding.
 
 ## 0.2.10 2021-03-04
-- Update test doesn't depend on mbed bootloader anymore
+- Update test does not depend on mbed bootloader anymore.
 
 ## 0.2.9  2021-01-15
-- Updated instructions
-- Updated python dependencies
+- Updated instructions.
+- Updated python dependencies.
 
 ## 0.2.8  2020-12-15
-- Update copyrights to Pelion
+- Update copyrights to Pelion.
 
 ## 0.2.7  2020-09-18
 - Manifest-tool 2.0.0 support.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ mbed-ls==1.8.*
 pytest==7.4.4
 pytest-html
 pyserial
-requests==2.31.0
+requests==2.32.3
 ws4py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 manifest-tool>=2.1.0
 mbed-ls==1.8.*
-pytest==6.2.*
+pytest==7.4.4
 pytest-html
 pyserial
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-manifest-tool>=2.1.0
+manifest-tool==2.6.2
 mbed-ls==1.8.*
 pytest==7.4.4
 pytest-html


### PR DESCRIPTION
* Python 3.8 as minimum (3.5 is EOL already long ago).
* Requests to 2.32.3 to match manifest-tool.
* Pytest 7.4.4 to also match manifest-tool.
* Manifest-tool itself to be 2.6.2 (as that matches the requests).
* Use the git config actions & add cleanup to MCCE-Test-Linux (and add manual dispatch).
 
We should be aligned with some of the versions, so that we could use the tooling with ONE venv, rather than many.
